### PR TITLE
Make electron an external dependency

### DIFF
--- a/packages/obsidian-plugin-cli/src/build.ts
+++ b/packages/obsidian-plugin-cli/src/build.ts
@@ -4,7 +4,7 @@ export const build = (options: esbuild.BuildOptions) => {
   return esbuild.build({
     bundle: true,
     platform: "node",
-    external: ["obsidian"],
+    external: ["obsidian", "electron"],
     format: "cjs",
     mainFields: ["browser", "module", "main"],
     ...options,


### PR DESCRIPTION
Someone reached out on discord and said this was failing
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install obsidian-plugin-cli@0.8.1-canary.55.34a0218.0
  # or 
  yarn add obsidian-plugin-cli@0.8.1-canary.55.34a0218.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
