### PR TITLE
Group `@types` packages in a single update PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
-  "extends": [
-    "config:base"
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "groupName": "definitelyTyped",
+      "matchPackagePrefixes": ["@types/"]
+    }
   ]
 }


### PR DESCRIPTION
Ensures that renovate groups all `@types/*` packages into a single PR. Should just reduce the update noise a bit. 